### PR TITLE
Expand glycan pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,11 @@ This tool is under GPL-3.0 license, see the LICENSE file for details.
 - This release includes the functionalities to generate reaction rules
 - This release includes the functionalities to predict, analyze and visualize metabolites.
 - This release includes the functionalities to find microorganism and enzymes.
+- This release includes an experimental pipeline for glycan metabolite
+  prediction, ``glyco_pipeline``, covering glycan input parsing,
+  reaction rule generation, multi-step prediction with scoring,
+  enzyme and pathway annotation and a simple CLI ``glyco_pipeline_cli.py``
+  that outputs a Graphviz representation of the reaction graph.
 
 ## Disclaimer 
 

--- a/glyco_pipeline_cli.py
+++ b/glyco_pipeline_cli.py
@@ -1,0 +1,64 @@
+"""Command line interface for the glycan pipeline."""
+
+import argparse
+from pathlib import Path
+from typing import List
+
+from microberx.glyco_pipeline import (
+    GlycanInputHandler,
+    RuleGenerator,
+    GlycanPredictor,
+    EnzymeAnnotator,
+    PathwayMapper,
+    OutputGenerator,
+    DataIntegrator,
+)
+
+
+def load_list(path: str) -> List[str]:
+    try:
+        with open(path) as fh:
+            return [line.strip() for line in fh if line.strip()]
+    except OSError:
+        return []
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Run glycan prediction pipeline")
+    ap.add_argument("input", help="GlyTouCan ID, SMILES or file path")
+    ap.add_argument("--format", dest="fmt", help="Input format")
+    ap.add_argument("--metabolites", help="File of detected metabolites")
+    ap.add_argument("--species", help="File of detected species")
+    args = ap.parse_args()
+
+    handler = GlycanInputHandler()
+    glycan, mol = handler.load_input(args.input, fmt=args.fmt)
+
+    rg = RuleGenerator()
+    rules = rg.generate_rules([])
+
+    predictor = GlycanPredictor(rules)
+    graph = predictor.run(mol)
+
+    annotator = EnzymeAnnotator()
+    rule_species = {}
+    for rule in rules:
+        info = annotator.annotate_rule(rule.rule_id, rule.ec)
+        rule_species[rule.rule_id] = info.get("species", [])
+
+    mapper = PathwayMapper()
+
+    metabolites = set(load_list(args.metabolites)) if args.metabolites else set()
+    species = set(load_list(args.species)) if args.species else set()
+    integrator = DataIntegrator(metabolites, species)
+
+    product_scores = {k: v for k, v in predictor.seen.items()}
+    adjusted_scores = integrator.adjust_scores(product_scores)
+
+    outgen = OutputGenerator()
+    report = outgen.report(graph)
+    print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/microberx/__init__.py
+++ b/microberx/__init__.py
@@ -23,6 +23,7 @@ from .MetaboliteAnalyzer import *
 from .MetaboliteVisualizer import *
 
 from .OmicsIntegrator import *
+from .glyco_pipeline import *
 
 __version__ = get_versions()["version"]
 

--- a/microberx/glyco_pipeline/__init__.py
+++ b/microberx/glyco_pipeline/__init__.py
@@ -1,0 +1,23 @@
+"""GlycoMicrobeRX pipeline modules."""
+
+from .glycan_input import GlycanInputHandler
+from .glycan_graph import MonosaccharideNode, GlycanGraph
+from .reaction_rules import ReactionRule, RuleGenerator
+from .predictor import GlycanPredictor
+from .enzyme_annotator import EnzymeAnnotator
+from .pathway_mapper import PathwayMapper
+from .output_generator import OutputGenerator
+from .integrator import DataIntegrator
+
+__all__ = [
+    "GlycanInputHandler",
+    "MonosaccharideNode",
+    "GlycanGraph",
+    "ReactionRule",
+    "RuleGenerator",
+    "GlycanPredictor",
+    "EnzymeAnnotator",
+    "PathwayMapper",
+    "OutputGenerator",
+    "DataIntegrator",
+]

--- a/microberx/glyco_pipeline/enzyme_annotator.py
+++ b/microberx/glyco_pipeline/enzyme_annotator.py
@@ -1,0 +1,26 @@
+"""Annotate reaction rules with enzyme and species information."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List, Optional
+
+
+class EnzymeAnnotator:
+    def __init__(self, db: Dict[str, Dict[str, List[str]]] | None = None) -> None:
+        """db maps rule_id or EC to species list"""
+        default = {
+            "3.2.1.x": {"species": ["Escherichia coli", "Bifidobacterium longum"]}
+        }
+        self.db = db or default
+
+    def annotate_rule(self, rule_id: str, ec: Optional[str] = None) -> Dict[str, List[str]]:
+        """Return species list for a rule."""
+        info = self.db.get(rule_id) or self.db.get(ec or "") or {}
+        return info
+
+    @classmethod
+    def from_json(cls, path: str) -> "EnzymeAnnotator":
+        with open(path) as fh:
+            data = json.load(fh)
+        return cls(data)

--- a/microberx/glyco_pipeline/glycan_graph.py
+++ b/microberx/glyco_pipeline/glycan_graph.py
@@ -1,0 +1,33 @@
+"""Simple graph representation for glycans."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
+
+
+@dataclass
+class MonosaccharideNode:
+    """A monosaccharide residue in a glycan."""
+
+    id: str
+    name: str
+    anomeric: str | None = None
+    ring_size: str | None = None
+    mods: Dict[str, str] | None = None
+    children: List[Tuple[str, int, int]] = field(default_factory=list)
+
+
+@dataclass
+class GlycanGraph:
+    """Graph model consisting of monosaccharide nodes."""
+
+    nodes: Dict[str, MonosaccharideNode] = field(default_factory=dict)
+    root: str | None = None
+
+    def add_node(self, node: MonosaccharideNode) -> None:
+        self.nodes[node.id] = node
+
+    def add_edge(self, parent_id: str, child_id: str, parent_pos: int, child_pos: int) -> None:
+        parent = self.nodes[parent_id]
+        parent.children.append((child_id, parent_pos, child_pos))

--- a/microberx/glyco_pipeline/glycan_input.py
+++ b/microberx/glyco_pipeline/glycan_input.py
@@ -1,0 +1,133 @@
+"""Glycan input handler for GlycoMicrobeRX pipeline."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Tuple
+
+try:
+    from glypy import Glycan
+except ImportError:  # pragma: no cover - optional dependency
+    Glycan = None
+
+from rdkit import Chem
+import requests
+
+from .glycan_graph import GlycanGraph, MonosaccharideNode
+
+
+logger = logging.getLogger(__name__)
+
+
+class GlycanInputHandler:
+    """Load and parse glycan inputs from IDs or files."""
+
+    def __init__(self, glytoucan_endpoint: str | None = None):
+        self.glytoucan_endpoint = (
+            glytoucan_endpoint
+            or "https://sparqlist.glyconavi.org/api/GTC-WURCS?id={}"
+        )
+
+    def load_input(
+        self, input_str: str, fmt: Optional[str] = None
+    ) -> Tuple[object, Chem.Mol | None]:
+        """Load a glycan structure.
+
+        Parameters
+        ----------
+        input_str:
+            GlyTouCan ID, file path or direct structure string.
+        fmt:
+            Explicit format: ``"wurcs"``, ``"smiles"`` or ``"glycoct"``.
+
+        Returns
+        -------
+        glycan_obj:
+            Parsed glycan object (glypy ``Glycan`` when available).
+        rdkit_mol:
+            Equivalent RDKit molecule if possible.
+        """
+        if fmt is None:
+            fmt = self._guess_format(input_str)
+        logger.info("Detected input format: %s", fmt)
+
+        if fmt == "glytoucan":
+            wurcs = self._fetch_wurcs(input_str)
+            fmt = "wurcs"
+            input_str = wurcs
+
+        if fmt == "wurcs" and Glycan is not None:
+            glycan = Glycan.from_wurcs(input_str)
+            graph = self._build_graph(glycan)
+            smiles = glycan.to_smiles()
+            mol = Chem.MolFromSmiles(smiles) if smiles else None
+            return graph, mol
+
+        if fmt == "smiles":
+            mol = Chem.MolFromSmiles(input_str)
+            if mol is None:
+                raise ValueError("SMILES parsing failed")
+            graph = GlycanGraph()
+            node = MonosaccharideNode(id="0", name="SMILES")
+            graph.add_node(node)
+            graph.root = "0"
+            return graph, mol
+
+        if fmt == "glycoct" and Glycan is not None:
+            glycan = Glycan.from_glycoct(input_str)
+            graph = self._build_graph(glycan)
+            smiles = glycan.to_smiles()
+            mol = Chem.MolFromSmiles(smiles) if smiles else None
+            return graph, mol
+
+        raise ValueError(f"Unsupported or unknown format: {fmt}")
+
+    def _guess_format(self, s: str) -> str:
+        if s.startswith("WURCS="):
+            return "wurcs"
+        if s.startswith("G") and len(s) == 8:
+            return "glytoucan"
+        if all(c.isalnum() for c in s) and len(s) == 8:
+            return "glytoucan"
+        if "." in s or "/" in s:
+            # maybe filepath
+            try:
+                with open(s) as fh:
+                    text = fh.read().strip()
+                return self._guess_format(text)
+            except OSError:
+                pass
+        return "smiles"
+
+    def _fetch_wurcs(self, glytoucan_id: str) -> str:
+        url = self.glytoucan_endpoint.format(glytoucan_id)
+        logger.info("Fetching %s from GlyTouCan", glytoucan_id)
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("wurcs", "")
+
+    def _build_graph(self, glycan: Glycan) -> GlycanGraph:
+        """Convert a ``glypy`` Glycan into ``GlycanGraph``."""
+        graph = GlycanGraph()
+        node_map: dict[int, str] = {}
+        for res in glycan.iternodes():
+            node_id = str(res.id)
+            node = MonosaccharideNode(
+                id=node_id,
+                name=getattr(res, "name", "?"),
+                anomeric=getattr(res, "anomeric_state", None),
+                ring_size=getattr(res, "ring_type", None),
+            )
+            graph.add_node(node)
+            node_map[res.id] = node_id
+        if glycan.root:
+            graph.root = node_map[glycan.root.id]
+        for res in glycan.iternodes():
+            if res.parent is not None:
+                parent_id = node_map[res.parent.id]
+                child_id = node_map[res.id]
+                parent_pos = getattr(res, "parent_position", 1) or 1
+                child_pos = getattr(res, "substituent_position", 1) or 1
+                graph.add_edge(parent_id, child_id, parent_pos, child_pos)
+        return graph

--- a/microberx/glyco_pipeline/integrator.py
+++ b/microberx/glyco_pipeline/integrator.py
@@ -1,0 +1,33 @@
+"""Integrate metabolomic and genomic data."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Set
+
+
+class DataIntegrator:
+    def __init__(self, metabolites: Set[str] | None = None, species: Set[str] | None = None) -> None:
+        self.metabolites = metabolites or set()
+        self.species = species or set()
+
+    def filter_metabolites(self, predicted: Iterable[str]) -> Dict[str, bool]:
+        return {m: m in self.metabolites for m in predicted}
+
+    def filter_species(self, rule_to_species: Dict[str, Iterable[str]]) -> Dict[str, bool]:
+        out = {}
+        for rule, sp in rule_to_species.items():
+            out[rule] = bool(self.species.intersection(set(sp)))
+        return out
+
+    def adjust_scores(self, product_scores: Dict[str, float]) -> Dict[str, float]:
+        """Boost scores if detected in datasets, penalize otherwise."""
+        adjusted = {}
+        for prod, score in product_scores.items():
+            factor = 1.0
+            if self.metabolites:
+                if prod in self.metabolites:
+                    factor *= 1.2
+                else:
+                    factor *= 0.8
+            adjusted[prod] = score * factor
+        return adjusted

--- a/microberx/glyco_pipeline/output_generator.py
+++ b/microberx/glyco_pipeline/output_generator.py
@@ -1,0 +1,23 @@
+"""Generate textual report for predictions."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+class OutputGenerator:
+    def __init__(self) -> None:
+        pass
+
+    def report(self, graph: Dict[str, List[tuple[str, List[str], float]]]) -> str:
+        lines = ["# Prediction Results\n"]
+        dot = ["digraph G {"]
+        for parent, edges in graph.items():
+            for rule_id, products, score in edges:
+                prod_str = ", ".join(products)
+                lines.append(f"{parent} --{rule_id} ({score:.2f})--> {prod_str}")
+                for p in products:
+                    dot.append(f'"{parent}" -> "{p}" [label="{rule_id} ({score:.2f})"];')
+        dot.append("}")
+        lines.append("\nGraphviz DOT:\n" + "\n".join(dot))
+        return "\n".join(lines)

--- a/microberx/glyco_pipeline/pathway_mapper.py
+++ b/microberx/glyco_pipeline/pathway_mapper.py
@@ -1,0 +1,26 @@
+"""Map metabolites to known pathways."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+class PathwayMapper:
+    def __init__(self, mapping: Dict[str, List[str]] | None = None) -> None:
+        default = {
+            "Glucose": ["Glycolysis", "Starch and sucrose metabolism"],
+            "Galactose": ["Galactose metabolism"],
+            "N-Acetylglucosamine": ["Amino sugar metabolism"],
+        }
+        self.mapping = mapping or default
+
+    def map_compound(self, name: str) -> List[str]:
+        return self.mapping.get(name, [])
+
+    @classmethod
+    def from_json(cls, path: str) -> "PathwayMapper":
+        import json
+
+        with open(path) as fh:
+            data = json.load(fh)
+        return cls(data)

--- a/microberx/glyco_pipeline/predictor.py
+++ b/microberx/glyco_pipeline/predictor.py
@@ -1,0 +1,53 @@
+"""Multi-step glycan transformation predictor."""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from typing import Dict, List, Tuple
+
+from rdkit import Chem
+
+from .reaction_rules import ReactionRule
+
+logger = logging.getLogger(__name__)
+
+
+class GlycanPredictor:
+    """Iteratively apply reaction rules to a glycan molecule."""
+
+    def __init__(self, rules: List[ReactionRule], max_steps: int = 5, score_threshold: float = 0.1) -> None:
+        self.rules = rules
+        self.max_steps = max_steps
+        self.score_threshold = score_threshold
+        self.graph: Dict[str, List[Tuple[str, List[str], float]]] = defaultdict(list)
+        self.seen: Dict[str, float] = {}
+
+    def _mol_key(self, mol: Chem.Mol) -> str:
+        return Chem.MolToSmiles(mol, canonical=True)
+
+    def run(self, start_mol: Chem.Mol) -> Dict[str, List[Tuple[str, List[str]]]]:
+        current = [(start_mol, 1.0)]
+        self.seen[self._mol_key(start_mol)] = 1.0
+        step = 0
+        while current and step < self.max_steps:
+            next_gen = []
+            for mol, score in current:
+                mkey = self._mol_key(mol)
+                for rule in self.rules:
+                    new_score = score * rule.score
+                    if new_score < self.score_threshold:
+                        continue
+                    for prods in rule.apply(mol):
+                        prod_keys = []
+                        for p in prods:
+                            key = self._mol_key(p)
+                            prod_keys.append(key)
+                            prev_score = self.seen.get(key, 0.0)
+                            if new_score > prev_score:
+                                self.seen[key] = new_score
+                                next_gen.append((p, new_score))
+                        self.graph[mkey].append((rule.rule_id, prod_keys, new_score))
+            current = next_gen
+            step += 1
+        return self.graph

--- a/microberx/glyco_pipeline/reaction_rules.py
+++ b/microberx/glyco_pipeline/reaction_rules.py
@@ -1,0 +1,74 @@
+"""Reaction rule objects and generator for glycans."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+
+@dataclass
+class ReactionRule:
+    """Representation of a reaction rule."""
+
+    rule_id: str
+    reaction_smarts: str
+    name: str | None = None
+    ec: str | None = None
+    enzyme: str | None = None
+    score: float = 1.0
+
+    def __post_init__(self) -> None:
+        self.compiled = None
+        try:
+            self.compiled = AllChem.ReactionFromSmarts(self.reaction_smarts)
+        except Exception:
+            self.compiled = None
+
+    def apply(self, mol: Chem.Mol) -> List[tuple[Chem.Mol, ...]]:
+        if self.compiled is None:
+            return []
+        try:
+            return list(self.compiled.RunReactants((mol,)))
+        except Exception:
+            return []
+
+
+class RuleGenerator:
+    """Generate reaction rules from data sources."""
+
+    def __init__(self) -> None:
+        self.rules: list[ReactionRule] = []
+
+    def load_from_file(self, path: str) -> None:
+        with open(path) as fh:
+            data = json.load(fh)
+        self.rules = [ReactionRule(**d) for d in data]
+
+    def save_to_file(self, path: str) -> None:
+        with open(path, "w") as fh:
+            json.dump([r.__dict__ for r in self.rules], fh, indent=2)
+
+    def generate_rules(self, sources: Iterable[str]) -> list[ReactionRule]:
+        """Generate a minimal set of glycosidic bond hydrolysis rules."""
+        self.rules = []
+        idx = 1
+        for conf in ["alpha", "beta"]:
+            for pos in range(2, 7):
+                smarts = (
+                    f"[C@H:1]-O[C@@H:2]>>[C@H:1]-O.[C@@H:2]-O"  # simplified
+                )
+                rule = ReactionRule(
+                    rule_id=f"R{idx:03d}",
+                    reaction_smarts=smarts,
+                    name=f"{conf}-1,{pos} cleavage",
+                    ec="3.2.1.x",
+                    enzyme="glycosidase",
+                    score=1.0,
+                )
+                self.rules.append(rule)
+                idx += 1
+        return self.rules

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ tqdm
 dash
 jupyter-dash
 dash-bio
-microberx
+microberxglypy


### PR DESCRIPTION
## Summary
- implement simple graph representation for glycans
- generate generic glycosidic cleavage rules
- update predictor with scoring and pruning
- add species/CAZy annotation stubs
- map common products to KEGG pathways
- produce Graphviz DOT output
- adjust scores using metabolomic evidence
- add minimal CLI for the glycan pipeline

## Testing
- `python -m py_compile $(git ls-files '*.py')`